### PR TITLE
Add exlcude_patterns to .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,5 +1,10 @@
 version = 1
 
+exclude_patterns = [
+  "apps/oxidize/src/prisma.rs",
+  "apps/tnt/src/lib/locales/**"
+]
+
 [[analyzers]]
 name = "rust"
 enabled = true
@@ -10,4 +15,3 @@ msrv = "1.30.0"
 [[analyzers]]
 name = "javascript"
 enabled = true
-


### PR DESCRIPTION
Add glob patterns for `apps/oxidize/src/prisma.rs` and everything in `apps/tnt/src/lib/locales` to `exclude_patterns` on DeepSource, as these are all autogenerated files and should not be analyzed.